### PR TITLE
Update malware-safe-chain workflow to use curl installation

### DIFF
--- a/.github/workflows/malware-safe-chain.yml
+++ b/.github/workflows/malware-safe-chain.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/malware-safe-chain.yml
+++ b/.github/workflows/malware-safe-chain.yml
@@ -1,26 +1,4 @@
-# Aikido Safe Chain - Malware Detection for Package Installation
-#
-# This workflow integrates Aikido Safe Chain to protect against malicious packages
-# during dependency installation in CI/CD pipelines.
-#
-# What is Aikido Safe Chain?
-# Aikido Safe Chain is a free security tool that prevents developers from installing
-# malware through package managers (npm, pnpm, yarn, npx, pnpx). It wraps around
-# package manager commands and verifies packages against Aikido Intel - Open Sources
-# Threat Intelligence before installation. When malware is detected, it blocks the
-# installation and alerts the user.
-#
-# Key features:
-# - Free to use, no tokens required
-# - Works with Node.js 18+
-# - Supports npm, pnpm, yarn, npx, and pnpx
-# - Currently offers limited scanning for pnpm (scans install command arguments)
-# - Full dependency tree scanning support coming soon for pnpm
-#
-# GitHub Repository: https://github.com/AikidoSec/safe-chain
-# Documentation: https://github.com/AikidoSec/safe-chain#usage-in-cicd
-
-name: Safe Chain Security Check
+name: Malware Safe Chain
 
 on:
   pull_request: ~
@@ -29,35 +7,19 @@ on:
       - main
 
 jobs:
-  safe-chain-check:
+  malware-safe-chain:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
+      - uses: actions/checkout@v4
+      - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Setup Node.js
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'pnpm'
 
-      - name: Install Aikido Safe Chain
-        run: |
-          npm install -g @aikidosec/safe-chain
-          safe-chain setup-ci
-        shell: bash
+      - name: Install safe-chain
+        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
 
-      - name: Install dependencies with malware protection
-        run: pnpm install
-        shell: bash
-
-      - name: Verify installation
-        run: |
-          echo "✅ All dependencies installed successfully with Aikido Safe Chain protection"
-          echo "📦 No malicious packages detected"
-        shell: bash
+      - name: Install dependencies with Safe Chain protection
+        run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This PR updates the malware-safe-chain workflow to use the latest curl-based installation method instead of the legacy npm installation, as recommended by the [safe-chain repository](https://github.com/AikidoSec/safe-chain).